### PR TITLE
Remove container for hero image on first page

### DIFF
--- a/book-template/assets/qcbs-big-image.html
+++ b/book-template/assets/qcbs-big-image.html
@@ -8,7 +8,8 @@
 </head>
 
 
-
+<!-- 
 <div class="hero-image-container"> 
   <img class= "hero-image" src="assets/images/jean-philippe-delberghe-75xPHEQBmvA-unsplash_hero_image.jpg">
 </div>
+--!>


### PR DESCRIPTION
Since we don't have a customized hero image for each workshop, it isn't the best use of space for the first page of the books. I've commented it out here rather than removed it, so we can always put it back if we find/make some custom hero images for each workshop. 